### PR TITLE
 fix : Resolve warning for run script build phase   🐛 

### DIFF
--- a/Healthy.xcodeproj/project.pbxproj
+++ b/Healthy.xcodeproj/project.pbxproj
@@ -389,6 +389,7 @@
 		};
 		F39D440A2A149CCC0039AEF8 /* SwiftGen */ = {
 			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
 			buildActionMask = 2147483647;
 			files = (
 			);


### PR DESCRIPTION
 Removing "run script build phase warnings"  by Unchecking (Based on dependency analysis) under the scripts we've added : 

<img width="522" alt="Screenshot 2023-05-19 at 9 23 14 PM" src="https://github.com/a7maad-ayman/GitHubFollowers/assets/87352168/8b527516-4b55-4190-8e25-b6061f9e522c">
<img width="319" alt="Screenshot 2023-05-19 at 9 22 57 PM" src="https://github.com/a7maad-ayman/GitHubFollowers/assets/87352168/2751834d-cf3a-4d18-aaee-c840c6e4a1af">
